### PR TITLE
feat: wordle solver userscript

### DIFF
--- a/dist/wordle-solver.user.js
+++ b/dist/wordle-solver.user.js
@@ -1,0 +1,109 @@
+// ==UserScript==
+// @name        Wordle Solver
+// @namespace   https://hixon.dev
+// @description Logs possible Wordle answers to the console after each guess
+// @match       https://www.nytimes.com/games/wordle/index.html
+// @version     0.1.0
+// @author      Michael Hixon
+// @run-at      document-idle
+// @downloadURL https://raw.githubusercontent.com/wondermike221/userscripts/main/dist/wordle-solver.user.js
+// @homepageURL https://github.com/wondermike221/userscripts
+// ==/UserScript==
+
+(function () {
+'use strict';
+
+const WORDS_URL = 'https://raw.githubusercontent.com/chidiwilliams/wordle/main/src/data/words.json';
+async function loadWords() {
+  const response = await fetch(WORDS_URL);
+  return response.json();
+}
+function getRevealedTiles() {
+  return Array.from(document.querySelectorAll('[data-state="correct"], [data-state="present"], [data-state="absent"]')).map(el => {
+    var _el$textContent$trim$, _el$textContent;
+    return {
+      letter: (_el$textContent$trim$ = (_el$textContent = el.textContent) == null ? void 0 : _el$textContent.trim().toLowerCase()) != null ? _el$textContent$trim$ : '',
+      state: el.getAttribute('data-state')
+    };
+  }).filter(tile => tile.letter.length === 1);
+}
+function buildConstraints(guesses) {
+  const correct = Array(5).fill(null);
+  const mustInclude = new Set();
+  const neverInWord = new Set();
+  for (const row of guesses) {
+    for (let i = 0; i < 5; i++) {
+      const {
+        letter,
+        state
+      } = row[i];
+      if (state === 'correct') {
+        correct[i] = letter;
+        mustInclude.add(letter);
+      } else if (state === 'present') {
+        mustInclude.add(letter);
+      } else {
+        neverInWord.add(letter);
+      }
+    }
+  }
+
+  // Only truly exclude letters that never appeared as correct/present
+  const excluded = [...neverInWord].filter(l => !mustInclude.has(l)).join('');
+  const included = [...mustInclude].join('');
+  const pattern = correct.map(l => l != null ? l : '.').join('');
+  return {
+    regex: new RegExp(`^${pattern}$`),
+    excluded,
+    included
+  };
+}
+function filterWords(words, regex, excluded, included) {
+  return words.filter(word => {
+    if (!regex.test(word)) return false;
+    for (const letter of excluded) {
+      if (word.includes(letter)) return false;
+    }
+    for (const letter of included) {
+      if (!word.includes(letter)) return false;
+    }
+    return true;
+  });
+}
+async function main() {
+  const words = await loadWords();
+  let lastGuessCount = 0;
+  let debounceTimer = null;
+  function check() {
+    const tiles = getRevealedTiles();
+    const completeRows = Math.floor(tiles.length / 5);
+    if (completeRows <= lastGuessCount) return;
+    lastGuessCount = completeRows;
+    const guesses = Array.from({
+      length: completeRows
+    }, (_, i) => tiles.slice(i * 5, i * 5 + 5));
+    const {
+      regex,
+      excluded,
+      included
+    } = buildConstraints(guesses);
+    const possible = filterWords(words, regex, excluded, included);
+    console.log(`[Wordle Solver] Guess ${completeRows}: ${possible.length} possible words remaining`);
+    console.log(possible);
+  }
+
+  // Debounce to let all 5 tile animations finish before computing
+  const observer = new MutationObserver(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(check, 500);
+  });
+  observer.observe(document.body, {
+    attributes: true,
+    subtree: true,
+    attributeFilter: ['data-state']
+  });
+  console.log('[Wordle Solver] Loaded. Watching for guesses...');
+}
+main();
+
+})();

--- a/dist/wordle-solver.user.js
+++ b/dist/wordle-solver.user.js
@@ -8,6 +8,7 @@
 // @run-at      document-idle
 // @downloadURL https://raw.githubusercontent.com/wondermike221/userscripts/main/dist/wordle-solver.user.js
 // @homepageURL https://github.com/wondermike221/userscripts
+// @grant       unsafeWindow
 // ==/UserScript==
 
 (function () {
@@ -72,6 +73,7 @@ function filterWords(words, regex, excluded, included) {
 }
 async function main() {
   const words = await loadWords();
+  unsafeWindow.wordleSolver = (regex = /.*/, excludedLetters = '', includedLetters = '') => filterWords(words, regex, excludedLetters, includedLetters);
   let lastGuessCount = 0;
   let debounceTimer = null;
   function check() {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -9,6 +9,7 @@ const userscripts = {
   'fedex-form-filler': 'src/fedex-form-filler/index.ts',
   'snow': 'src/snow/index.ts',
   'shadow-query-console': 'src/shadow-query-console/index.ts',
+  'wordle-solver': 'src/wordle-solver/index.ts',
   // 'fulfillment-fedex-filler': 'src/fulfillment-fedex-filler/index.ts',
   // 'peoplex-scraper': 'src/peoplex-scraper/index.ts',
 };

--- a/src/wordle-solver/index.ts
+++ b/src/wordle-solver/index.ts
@@ -1,0 +1,119 @@
+import './meta.js?userscript-metadata';
+
+const WORDS_URL =
+  'https://raw.githubusercontent.com/chidiwilliams/wordle/main/src/data/words.json';
+
+type TileState = 'correct' | 'present' | 'absent';
+
+interface Tile {
+  letter: string;
+  state: TileState;
+}
+
+async function loadWords(): Promise<string[]> {
+  const response = await fetch(WORDS_URL);
+  return response.json();
+}
+
+function getRevealedTiles(): Tile[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      '[data-state="correct"], [data-state="present"], [data-state="absent"]',
+    ),
+  )
+    .map((el) => ({
+      letter: el.textContent?.trim().toLowerCase() ?? '',
+      state: el.getAttribute('data-state') as TileState,
+    }))
+    .filter((tile) => tile.letter.length === 1);
+}
+
+function buildConstraints(guesses: Tile[][]): {
+  regex: RegExp;
+  excluded: string;
+  included: string;
+} {
+  const correct: (string | null)[] = Array(5).fill(null);
+  const mustInclude = new Set<string>();
+  const neverInWord = new Set<string>();
+
+  for (const row of guesses) {
+    for (let i = 0; i < 5; i++) {
+      const { letter, state } = row[i];
+      if (state === 'correct') {
+        correct[i] = letter;
+        mustInclude.add(letter);
+      } else if (state === 'present') {
+        mustInclude.add(letter);
+      } else {
+        neverInWord.add(letter);
+      }
+    }
+  }
+
+  // Only truly exclude letters that never appeared as correct/present
+  const excluded = [...neverInWord].filter((l) => !mustInclude.has(l)).join('');
+  const included = [...mustInclude].join('');
+  const pattern = correct.map((l) => l ?? '.').join('');
+
+  return { regex: new RegExp(`^${pattern}$`), excluded, included };
+}
+
+function filterWords(
+  words: string[],
+  regex: RegExp,
+  excluded: string,
+  included: string,
+): string[] {
+  return words.filter((word) => {
+    if (!regex.test(word)) return false;
+    for (const letter of excluded) {
+      if (word.includes(letter)) return false;
+    }
+    for (const letter of included) {
+      if (!word.includes(letter)) return false;
+    }
+    return true;
+  });
+}
+
+async function main() {
+  const words = await loadWords();
+  let lastGuessCount = 0;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function check() {
+    const tiles = getRevealedTiles();
+    const completeRows = Math.floor(tiles.length / 5);
+
+    if (completeRows <= lastGuessCount) return;
+    lastGuessCount = completeRows;
+
+    const guesses: Tile[][] = Array.from({ length: completeRows }, (_, i) =>
+      tiles.slice(i * 5, i * 5 + 5),
+    );
+    const { regex, excluded, included } = buildConstraints(guesses);
+    const possible = filterWords(words, regex, excluded, included);
+
+    console.log(
+      `[Wordle Solver] Guess ${completeRows}: ${possible.length} possible words remaining`,
+    );
+    console.log(possible);
+  }
+
+  // Debounce to let all 5 tile animations finish before computing
+  const observer = new MutationObserver(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(check, 500);
+  });
+
+  observer.observe(document.body, {
+    attributes: true,
+    subtree: true,
+    attributeFilter: ['data-state'],
+  });
+
+  console.log('[Wordle Solver] Loaded. Watching for guesses...');
+}
+
+main();

--- a/src/wordle-solver/index.ts
+++ b/src/wordle-solver/index.ts
@@ -1,5 +1,15 @@
 import './meta.js?userscript-metadata';
 
+declare global {
+  interface Window {
+    wordleSolver: (
+      regex?: RegExp,
+      excludedLetters?: string,
+      includedLetters?: string,
+    ) => string[];
+  }
+}
+
 const WORDS_URL =
   'https://raw.githubusercontent.com/chidiwilliams/wordle/main/src/data/words.json';
 
@@ -79,6 +89,13 @@ function filterWords(
 
 async function main() {
   const words = await loadWords();
+
+  unsafeWindow.wordleSolver = (
+    regex = /.*/,
+    excludedLetters = '',
+    includedLetters = '',
+  ) => filterWords(words, regex, excludedLetters, includedLetters);
+
   let lastGuessCount = 0;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/wordle-solver/meta.js
+++ b/src/wordle-solver/meta.js
@@ -5,6 +5,7 @@
 // @match       https://www.nytimes.com/games/wordle/index.html
 // @version     0.1.0
 // @author      process.env.AUTHOR
+// @grant       unsafeWindow
 // @run-at      document-idle
 // @downloadURL https://raw.githubusercontent.com/wondermike221/userscripts/main/dist/wordle-solver.user.js
 // @homepageURL https://github.com/wondermike221/userscripts

--- a/src/wordle-solver/meta.js
+++ b/src/wordle-solver/meta.js
@@ -1,0 +1,19 @@
+// ==UserScript==
+// @name        Wordle Solver
+// @namespace   https://hixon.dev
+// @description Logs possible Wordle answers to the console after each guess
+// @match       https://www.nytimes.com/games/wordle/index.html
+// @version     0.1.0
+// @author      process.env.AUTHOR
+// @run-at      document-idle
+// @downloadURL https://raw.githubusercontent.com/wondermike221/userscripts/main/dist/wordle-solver.user.js
+// @homepageURL https://github.com/wondermike221/userscripts
+// ==/UserScript==
+
+/**
+ * Code here will be ignored on compilation. So it's a good place to leave messages to developers.
+ *
+ * - The `@grant`s used in your source code will be added automatically by `rollup-plugin-userscript`.
+ *   However you have to add explicitly those used in required resources.
+ * - `process.env.VERSION` and `process.env.AUTHOR` will be loaded from `package.json`.
+ */


### PR DESCRIPTION
## Summary

- Adds a new `wordle-solver` userscript that runs on `https://www.nytimes.com/games/wordle/index.html`
- After each guess, automatically logs the remaining possible answers to the console by watching tile `data-state` attribute changes via `MutationObserver`
- Exposes `wordleSolver(regex?, excludedLetters?, includedLetters?)` on `unsafeWindow` for manual console use — same interface as the existing `]wordl` AHK hotstring, replacing the need for it
- Word list fetched from the same source as the AHK snippet (`chidiwilliams/wordle` on GitHub)

## Test plan

- [ ] Install `dist/wordle-solver.user.js` in Tampermonkey/Violentmonkey
- [ ] Open https://www.nytimes.com/games/wordle/index.html and confirm `[Wordle Solver] Loaded.` appears in console
- [ ] Make a guess and confirm possible words are logged after tile animations complete (~500ms)
- [ ] Call `wordleSolver(/a..../, 'oes', 'r')` manually in the console and confirm it returns a filtered list

🤖 Generated with [Claude Code](https://claude.com/claude-code)