### PR TITLE
fix(wordle-solver): yellow-position constraints and keyboard contamination

### DIFF
--- a/dist/wordle-solver.user.js
+++ b/dist/wordle-solver.user.js
@@ -20,7 +20,8 @@ async function loadWords() {
   return response.json();
 }
 function getRevealedTiles() {
-  return Array.from(document.querySelectorAll('[data-state="correct"], [data-state="present"], [data-state="absent"]')).map(el => {
+  // Exclude <button> elements so keyboard keys (same data-state values) aren't mixed in
+  return Array.from(document.querySelectorAll(':not(button)[data-state="correct"], :not(button)[data-state="present"], :not(button)[data-state="absent"]')).map(el => {
     var _el$textContent$trim$, _el$textContent;
     return {
       letter: (_el$textContent$trim$ = (_el$textContent = el.textContent) == null ? void 0 : _el$textContent.trim().toLowerCase()) != null ? _el$textContent$trim$ : '',
@@ -30,6 +31,9 @@ function getRevealedTiles() {
 }
 function buildConstraints(guesses) {
   const correct = Array(5).fill(null);
+  const presentAt = Array.from({
+    length: 5
+  }, () => new Set());
   const mustInclude = new Set();
   const neverInWord = new Set();
   for (const row of guesses) {
@@ -42,6 +46,7 @@ function buildConstraints(guesses) {
         correct[i] = letter;
         mustInclude.add(letter);
       } else if (state === 'present') {
+        presentAt[i].add(letter);
         mustInclude.add(letter);
       } else {
         neverInWord.add(letter);
@@ -52,7 +57,11 @@ function buildConstraints(guesses) {
   // Only truly exclude letters that never appeared as correct/present
   const excluded = [...neverInWord].filter(l => !mustInclude.has(l)).join('');
   const included = [...mustInclude].join('');
-  const pattern = correct.map(l => l != null ? l : '.').join('');
+  const pattern = correct.map((l, i) => {
+    if (l) return l;
+    const notHere = [...presentAt[i]].join('');
+    return notHere ? `[^${notHere}]` : '.';
+  }).join('');
   return {
     regex: new RegExp(`^${pattern}$`),
     excluded,
@@ -90,7 +99,7 @@ async function main() {
       included
     } = buildConstraints(guesses);
     const possible = filterWords(words, regex, excluded, included);
-    console.log(`[Wordle Solver] Guess ${completeRows}: ${possible.length} possible words remaining`);
+    console.log(`[Wordle Solver] Guess ${completeRows}: regex=${regex} excluded="${excluded}" included="${included}" → ${possible.length} possible words remaining`);
     console.log(possible);
   }
 

--- a/src/wordle-solver/index.ts
+++ b/src/wordle-solver/index.ts
@@ -26,9 +26,10 @@ async function loadWords(): Promise<string[]> {
 }
 
 function getRevealedTiles(): Tile[] {
+  // Exclude <button> elements so keyboard keys (same data-state values) aren't mixed in
   return Array.from(
     document.querySelectorAll<HTMLElement>(
-      '[data-state="correct"], [data-state="present"], [data-state="absent"]',
+      ':not(button)[data-state="correct"], :not(button)[data-state="present"], :not(button)[data-state="absent"]',
     ),
   )
     .map((el) => ({
@@ -44,6 +45,10 @@ function buildConstraints(guesses: Tile[][]): {
   included: string;
 } {
   const correct: (string | null)[] = Array(5).fill(null);
+  const presentAt: Set<string>[] = Array.from(
+    { length: 5 },
+    () => new Set<string>(),
+  );
   const mustInclude = new Set<string>();
   const neverInWord = new Set<string>();
 
@@ -54,6 +59,7 @@ function buildConstraints(guesses: Tile[][]): {
         correct[i] = letter;
         mustInclude.add(letter);
       } else if (state === 'present') {
+        presentAt[i].add(letter);
         mustInclude.add(letter);
       } else {
         neverInWord.add(letter);
@@ -64,7 +70,13 @@ function buildConstraints(guesses: Tile[][]): {
   // Only truly exclude letters that never appeared as correct/present
   const excluded = [...neverInWord].filter((l) => !mustInclude.has(l)).join('');
   const included = [...mustInclude].join('');
-  const pattern = correct.map((l) => l ?? '.').join('');
+  const pattern = correct
+    .map((l, i) => {
+      if (l) return l;
+      const notHere = [...presentAt[i]].join('');
+      return notHere ? `[^${notHere}]` : '.';
+    })
+    .join('');
 
   return { regex: new RegExp(`^${pattern}$`), excluded, included };
 }
@@ -113,7 +125,7 @@ async function main() {
     const possible = filterWords(words, regex, excluded, included);
 
     console.log(
-      `[Wordle Solver] Guess ${completeRows}: ${possible.length} possible words remaining`,
+      `[Wordle Solver] Guess ${completeRows}: regex=${regex} excluded="${excluded}" included="${included}" → ${possible.length} possible words remaining`,
     );
     console.log(possible);
   }


### PR DESCRIPTION
## Summary

- **Yellow-position exclusion**: `buildConstraints` now tracks `presentAt[i]` per position so yellow (present) tiles generate `[^x]` exclusions in the regex instead of `.` — after guessing "audio" this produces `.[^u][^d]..` as expected
- **Keyboard contamination**: NYT Wordle keyboard keys use the same `data-state="correct/present/absent"` values as board tiles; the broad `querySelectorAll` was mixing them in, inflating the row count and injecting wrong letter-position assignments (root cause of 0-word results and "Guess 5" shown for the 4th guess). Fixed with `:not(button)` to exclude keyboard key elements.
- **Constraint logging**: auto log now prints `regex=`, `excluded=`, and `included=` so future issues can be diagnosed without manual console calls

## Test plan

- [ ] Load the userscript on NYT Wordle
- [ ] After first guess, verify console log shows `[^x]` exclusions for any yellow tiles
- [ ] Verify guess count in log matches actual guess number
- [ ] Verify suggestions are non-empty and match the expected constraint set

🤖 Generated with [Claude Code](https://claude.com/claude-code)